### PR TITLE
👩‍🎓 Consume affiliation/collaboration values as objects with 'name'

### DIFF
--- a/examples/myst.yml
+++ b/examples/myst.yml
@@ -10,22 +10,29 @@ project:
     - name: Bugs Bunny
       orcid: 0000-0002-5591-9220
       affiliations:
-        - Looney Tune Studios
-      collaborations:
-        - cool collaboration
+        - lts
+        - cc
     - name: Roger Rabbit
       corresponding: true
       email: Roger.Rabbit@LooneyTuneStudios.com
       website: https://www.looneytunestudio.com
       affiliations:
-        -  Looney Tune Studios
+        - lts
     - name: Mickey Mouse
       affiliations:
-        - Disney World
+        - dw
       website: https://www.disneyworld.com
   github: https://github.com/dressedfez/myst_template_physical_review_journals
   # bibliography: []
   license: CC-BY-4.0
+  affiliations:
+    - id: lts
+      name: Looney Tune Studios
+    - id: dw
+      name: Disney World
+    - id: cc
+      name: cool collaboration
+      collaboration: true
 site:
   template: book-theme
   # title:

--- a/template.tex
+++ b/template.tex
@@ -91,13 +91,13 @@
 
 [#- if author.affiliations #]
 [#- for affiliation in author.affiliations -#]
-\affiliation{[-- affiliation.value --]}
+\affiliation{[-- affiliation.value.name --]}
 [#- endfor -#]
 [# endif -#]
 
 [#- if author.collaborations #]
 [#- for collaboration in author.collaborations -#]
-\collaboration{[-- collaboration.value --]}\noaffiliation
+\collaboration{[-- collaboration.value.name --]}\noaffiliation
 [#- endfor -#]
 [# endif -#]
 [#- endfor -#]


### PR DESCRIPTION
This PR updates the template to work with improved affiliations in MyST frontmatter added here: https://github.com/executablebooks/mystmd/pull/535

With this change, affiliations are now objects with `name`, `address`, etc. that are able to be referenced by `id`. Notably, they also have `collaboration` boolean (so collaborations are simply affiliations with this flag set to true).

In the template, I just changed `affiliation.value`/`collaboration.value` to `affiliation.value.name`/`collaboration.value.name`. In the example myst.yml file, I moved the affiliations to separate objects, setting the collaboration flag where necessary.

A couple notes:
- Affiliations will still work when defined as simple strings, as found in the page frontmatter here: https://github.com/dressedfez/myst_template_physical_review_journals/blob/main/examples/paper.md. Since there are no collaborations or anything there, I just left that file as-is.
- There may be more updates you would like to make to this template to support the other affiliation data; for now, this just maintains existing functionality.

Let me know if you have any questions or concerns!